### PR TITLE
Don't destroy stack traces when rethrowing exceptions

### DIFF
--- a/PaymentProcess/AuthorizeRequest.cs
+++ b/PaymentProcess/AuthorizeRequest.cs
@@ -100,7 +100,7 @@ namespace PaymentProcess
                 Trace.WriteLineIf(ts.TraceError, "\tException was thrown.");
                 Trace.WriteLineIf(ts.TraceError, "\t" + ex.Message);
                 Trace.WriteLineIf(ts.TraceError, "\t" + ex.StackTrace);
-                throw ex;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
On a more general note, this entire `catch` block has no purpose.
